### PR TITLE
fix(external): Use weidu_external for backup

### DIFF
--- a/Loretakers/Setup-Loretakers.tp2
+++ b/Loretakers/Setup-Loretakers.tp2
@@ -5,7 +5,7 @@
  *
  *
  *************************************************************************/
-BACKUP ~Loretakers/backup~
+BACKUP ~weidu_external/backup/Loretakers~
 AUTHOR ~Acifer~
 VERSION ~V 2.0~
 


### PR DESCRIPTION
This fixes annother very minor issue I had, I removed the loretaker's folder and my backup was gone. The general advise is to use weidu_external for backup, incase someone silly like me removes your mod folder from the directory.
